### PR TITLE
Make a small cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /rhvoice_temp.wav
 /temp/
 /plugins/plugin_tts_silero.py
+*.pyc

--- a/mpcapi/core.py
+++ b/mpcapi/core.py
@@ -2,7 +2,7 @@
 
 # python std lib
 import pprint
-from collections import Callable
+from collections.abc import Callable
 
 # 3rd party imports
 import requests


### PR DESCRIPTION
Every Python project with initialized git should have "`*.pyc`" in its .gitignore file, I think.

Also, do `Callable` import from `collections.abc` instead of `collections` - in Python 3.10 there was an `ImportError` exception.