### PR TITLE
Add numpy in requirements; add venv in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@
 /rhvoice_temp.wav
 /temp/
 /plugins/plugin_tts_silero.py
+/venv/
+/.venv/
 *.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sounddevice
 soundfile
 pyautogui
 requests
+numpy


### PR DESCRIPTION
Добавил в .gitignore папки venv и .venv - типовые названия для папок виртуальной среды. Запуск из виртуальный среды позволил найти проблему: отсутствие numpy в requirements. Была получена ошибка по истечении таймера:
```
Input (cmd):  ирина таймер одна минута
New Timer ID = 0  curtime= 1646187149.763431 duration= 60 endtime= 1646187209.763431
End Timer ID = 0  curtime= 1646187209.8347058 endtime= 1646187209.763431
ModuleNotFoundError: No module named 'numpy'
```