### PR TITLE
Возможность кэширования wav файлов, создаваемых TTS движком

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ https://github.com/timhok/IreneVA-hassio-script-trigger-plugin
     "mpcHcPath": "C:\\Program Files (x86)\\K-Lite Codec Pack\\MPC-HC64\\mpc-hc64_nvo.exe", # путь до MPC HC, если используете
     "mpcIsUse": true, # используется ли MPC HC?
     "mpcIsUseHttpRemote": true, # MPC HC - включено ли управление через веб-интерфейс?
+    "useTTSCache": false, # при установке true в папке tts_cache будет кэшировать .wav файлы со сгенерированными TTS-движком ответами
     "ttsEngineId": "pyttsx", # используемый TTS-движок
     "v": "1.7", # версия плагина core. Обновляется автоматически, не трогайте
     "voiceAssNames": "ирина|ирины|ирину" # Если это появится в звуковом потоке, то дальше будет команда. (Различные имена помощника, рекомендуется несколько)

--- a/plugins/core.py
+++ b/plugins/core.py
@@ -16,6 +16,7 @@ def start(core:VACore):
 
             "isOnline": False,
             #"ttsIndex": 0,
+            "useTTSCache": False,
             "ttsEngineId": "pyttsx",
             "ttsEngineId2": "", # двиг для прямой озвучки на сервере. Если пуст - используется ttsEngineId
             "playWavEngineId": "audioplayer",
@@ -53,6 +54,11 @@ def start_with_options(core:VACore, manifest:dict):
     import os
     if not os.path.exists(core.tmpdir):
         os.mkdir(core.tmpdir)
+
+    core.useTTSCache = options["useTTSCache"]
+    core.tts_cache_dir = "tts_cache"
+    if not os.path.exists(core.tts_cache_dir):
+        os.mkdir(core.tts_cache_dir)
 
     import lingua_franca
     lingua_franca.load_language(options["linguaFrancaLang"])


### PR DESCRIPTION
Добавлена опция useTTSCache, при значении true будет кэшировать ответы в папке tts_cache

Примеры, почему это может быть полезно:

- повышения скорости ответа ассистента, запущенного на слабом железе
- воспроизведение заранее закешированных на другом устройстве ответов TTS движка silero v3 на устройстве, не поддерживающем AVX2 инструкции и потому не позволяющем использовать этот TTS движок