### PR TITLE
Исправление контекста при воспроизведении ответа сервера на клиенте

### DIFF
--- a/runva_webapi.py
+++ b/runva_webapi.py
@@ -74,6 +74,13 @@ async def sendRawTxt(rawtxt:str,returnFormat:str = "none"):
     else:
         return "NO_VA_NAME"
 
+
+# Сообщает серверу, что клиент воспроизвёл ответ и можно начать отсчёт таймера контекста
+@app.get("/replyWasGiven")
+async def replyWasGiven():
+    core.context_start_timer()
+
+
 # Запускает внутреннюю процедуру проверки таймеров. Должна запускаться периодически
 @app.get("/updTimers")
 async def updTimers():

--- a/vacore.py
+++ b/vacore.py
@@ -377,7 +377,14 @@ class VACore(JaaCore):
         self.context = context
         self.contextTimerLastDuration = duration
         self.contextTimer = Timer(duration,self._context_clear_timer)
-        self.contextTimer.start()
+
+        remoteTTSList = self.remoteTTS.split(",")
+        if "saytext" not in remoteTTSList and "saywav" not in remoteTTSList:
+            self.context_start_timer()
+
+    def context_start_timer(self):
+        if self.contextTimer is not None:
+            self.contextTimer.start()
 
     #def _timer_context
     def _context_clear_timer(self):


### PR DESCRIPTION
Добавлен запрос по HTTP от клиента к серверу, сообщающий о завершении воспроизведения ответа.

Не уверен, что предусмотрел все варианты работы (ttsFormat: `saytxt` или `none,saywav` и т.д.), прошу проверить.

Если в этом PR всё ок, то далее на стороне клиента необходимо вызвать `requests.get(baseUrl+"replyWasGiven")` после воспроизведения звука в функции `def play_wav(wavfile)`. А для этого нужно в `play_wav.py` получить адрес сервера из конфигурации. Полагаю, следует вынести функцию получения конфигурации в отдельный файл и его импортировать как в play_wav.py, так и в run_remoteva_*