### PR TITLE
Тестовое внедрение машинного обучения для нечёткого распознавания команд

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 numpy
 audioplayer
 python-dateutil~=2.6.0
+scikit-learn~=1.2.0

--- a/runva_cmdline.py
+++ b/runva_cmdline.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     time.sleep(0.5) # небольшой таймаут
     cmd = "привет"
     try:
-        cmd_core.execute_next(cmd,None)
+        cmd_core.run_input_str(f"{cmd_core.voiceAssNames[0]} {cmd}", None)
     except:
         if cmd == "привет":
             print("Ошибка при запуске команды 'привет'. Скорее всего, проблема с TTS.")
@@ -29,4 +29,4 @@ if __name__ == "__main__":
         if cmd == "exit":
             break
 
-        cmd_core.execute_next(cmd,None)
+        cmd_core.run_input_str(f"{cmd_core.voiceAssNames[0]} {cmd}", None)


### PR DESCRIPTION
Сделано на основе наработок из видео [Крендель - Голосовой ассистент на python c искусственным интеллектом и машинным обучением](https://www.youtube.com/watch?v=MXdsPKZyZ48) (доступно в репозитории https://github.com/PythonHubStudio/Offline-Voice-Assistant-with-Machine-Learning-on-python)

В случае, если команда не найдена среди возможных, запускается попытка предсказания. Благодаря этому команду "Ирина погода" можно вызвать даже словами "Ирина скажи какая сейчас погода".

Минусы:
* При замене команды на предсказанную теряются постфиксы команды. То есть если сказать "Ирина пожалуйста поставь таймер на 1 минуту" будет заменено на "Ирина поставь таймер" с дефолтными 5 минутами.
* Помогает обрезать лишние сказанные слова в команде, но на словоформы не реагирует. "Ирина как с погодой" не будет распознано.
* В этой реализации self.data_set, содержащий словарь всех доступных команд, строится как словарь `{'погода': 'погода'}`, т.е. дублируются значения. Не знаю, как это упростить.

Это просто концепт, не претендующий на реальное использование. Но у себя пожалуй буду это использовать, потому что так меньше мороки с запоминанием команд, какое-нибудь слово да сработает.