### PR TITLE
fix(runva_gigastt): endpoint_mode=assistant, чтобы final не резал фразу

### DIFF
--- a/runva_gigastt.py
+++ b/runva_gigastt.py
@@ -161,7 +161,7 @@ async def run_session(core, websocket, ready):
             samplerate = 16000
 
         # configure must be sent before the first audio frame
-        await websocket.send(json.dumps({"type": "configure", "sample_rate": samplerate, "punctuation": False, "itn": False}))
+        await websocket.send(json.dumps({"type": "configure", "sample_rate": samplerate, "punctuation": False, "itn": False, "endpoint_mode": "assistant"}))
 
         # drop audio captured while there was no live session
         while not audio_queue.empty():


### PR DESCRIPTION
## Зачем

После merge #75 на живом mic final приходит слишком рано
(`ирина` отдельно, потом `ирина привет`). Classic-плагины ждут
целую фразу, как у Vosk.

Причина — default endpointing gigastt (`auto` + blank-run ~600 ms),
не runner как транспорт.

## Что сделано

В `configure` для сессии:

- `endpoint_mode: "assistant"` — не резать utterance по blank-run;
  final по паузе (VAD) / stop
- как и раньше: `punctuation: false`, `itn: false`

## Важно (сервер)

Для `assistant` на сервере нужен VAD, иначе final почти не придёт
до явной паузы/stop:

```sh
gigastt serve --endpoint-mode assistant --vad --vad-min-silence-ms 1200
```

(`endpoint_mode` / `min_silence` можно задать и на serve; runner
фиксирует режим ассистента per-session, даже если serve поднят с `auto`.)

## Как проверить

1. `gigastt serve --vad --vad-min-silence-ms 1200`
2. `python runva_gigastt.py --debug`
3. Сказать «Ирина привет» нормальным темпом → один final с полной фразой

## Scope

Только `runva_gigastt.py`. Ядро / плагины / README не трогаем.